### PR TITLE
feat: make LaunchAndHook extern

### DIFF
--- a/AfxCppCli/AfxCppCli.h
+++ b/AfxCppCli/AfxCppCli.h
@@ -25,3 +25,13 @@ public:
 };
 
 } // namespace AfxCppCli {
+
+extern "C" __declspec(dllexport)
+bool __cdecl LaunchAndHook(char* programPath, char* cmdLine, char* hookPath, char* environment)
+{
+	String^ env = nullptr;
+	if (environment != nullptr) {
+		env = gcnew String(environment);
+	}
+	return AfxCppCli::AfxHook::LauchAndHook(gcnew String(programPath), gcnew String(cmdLine), gcnew String(hookPath), env);
+};

--- a/AfxCppCli/loader.cpp
+++ b/AfxCppCli/loader.cpp
@@ -308,7 +308,7 @@ bool CustomLoader(System::String ^ strHookPath, System::String ^ strProgramPath,
 {
 	System::String ^ strDllDirectory = System::IO::Path::GetDirectoryName( strHookPath ); // maybe we should check that strDllDirectory <= MAXPATH-2 here?
 	System::String ^ strProgramDirectory = System::IO::Path::GetDirectoryName( strProgramPath );
-	System::String ^ strImageFileName = System::AppDomain::CurrentDomain->BaseDirectory + "\\AfxHook.dat";
+	System::String ^ strImageFileName = strDllDirectory + "\\AfxHook.dat";
 
 	System::Text::StringBuilder ^strOptsB = gcnew System::Text::StringBuilder( "\"" );
 	strOptsB->Append( strProgramPath );


### PR DESCRIPTION
Hi!

I integrated HLAE in my app https://github.com/akiver/CSGO-Demos-Manager, but since a reference to **AfxCppCli** is necessary, users have to manually replace dlls or wait for the next release to have the last HLAE release (and so fix possible crashs due to CSGO updates). To solve this problem I made the **LauchAndHook** function extern.

Does it on purpose that **AfxHook.dat** has to be next to the exe that started the actual thread? (https://github.com/akiver/advancedfx/commit/2caaaea2c78faadc9b3b61668dee195d179d5ab8#diff-c2a1a3307814ca70764ab0a7b1451d96L311)

I had to change it because it's not necessary the case.
I assumed that the **AfxHook.dat** has to be next to DLLs (basically like when you download the HLAE archive).

Thanks