### PR TITLE
TAS execution capture mode

### DIFF
--- a/AfxHookGoldSrc/filming.cpp
+++ b/AfxHookGoldSrc/filming.cpp
@@ -1925,28 +1925,19 @@ void FilmingStream::Capture(double time, CMdt_Media_RAWGLPIC * usePic, float sps
 		}	
 	}
 
-	if (print_frame->value)
-	{
-		if (time < m_NextFrameIsAt)
-		{
-			pEngfuncs->Con_Printf("Skipping a frame (time = %.8f, m_NextFrameIsAt = %.8f).\n", time, m_NextFrameIsAt);
-		}
-		else
-		{
-			size_t missedFrames = static_cast<size_t>((time - m_NextFrameIsAt) / (1.0 / spsHint)) + 1;
-			pEngfuncs->Con_Printf("Writing %lu missed frames (time = %.8f).\n", missedFrames, time);
-		}
-	}
-
 	if (m_NextFrameIsAt == 0.0)
 	{
 		m_PreviousFrame = *usePic;
 	}
 
+	size_t framesWritten = 0;
+
 	while (m_NextFrameIsAt < time)
 	{
 		WriteFrame(m_PreviousFrame, m_NextFrameIsAt);
 		m_NextFrameIsAt += (1.0 / spsHint);
+
+		++framesWritten;
 	}
 
 	m_PreviousFrame = *usePic;
@@ -1955,6 +1946,25 @@ void FilmingStream::Capture(double time, CMdt_Media_RAWGLPIC * usePic, float sps
 	{
 		WriteFrame(m_PreviousFrame, m_NextFrameIsAt);
 		m_NextFrameIsAt += (1.0 / spsHint);
+
+		++framesWritten;
+	}
+
+	if (print_frame->value)
+	{
+		if (framesWritten > 0)
+		{
+			pEngfuncs->Con_Printf(
+				"Wrote %lu frame%s (time = %.8f, m_NextFrameIsAt = %.8f).\n",
+				framesWritten,
+				framesWritten > 1 ? "s" : "",
+				time,
+				m_NextFrameIsAt);
+		}
+		else
+		{
+			pEngfuncs->Con_Printf("Skipping a frame (time = %.8f, m_NextFrameIsAt = %.8f).\n", time, m_NextFrameIsAt);
+		}
 	}
 }
 

--- a/AfxHookGoldSrc/filming.cpp
+++ b/AfxHookGoldSrc/filming.cpp
@@ -1927,7 +1927,9 @@ void FilmingStream::Capture(double time, CMdt_Media_RAWGLPIC * usePic, float sps
 
 	if (time < m_NextFrameIsAt)
 	{
-		pEngfuncs->Con_Printf("Skipping a frame (time = %.8f, m_NextFrameIsAt = %.8f).\n", time, m_NextFrameIsAt);
+		if (print_frame->value)
+			pEngfuncs->Con_Printf("Skipping a frame (time = %.8f, m_NextFrameIsAt = %.8f).\n", time, m_NextFrameIsAt);
+
 		m_PreviousFrame = *usePic;
 		return;
 	}
@@ -1938,7 +1940,9 @@ void FilmingStream::Capture(double time, CMdt_Media_RAWGLPIC * usePic, float sps
 	}
 
 	size_t missedFrames = static_cast<size_t>((time - m_NextFrameIsAt) / (1.0 / spsHint)) + 1;
-	pEngfuncs->Con_Printf("Writing %lu missed frames (time = %.8f).\n", missedFrames, time);
+
+	if (print_frame->value)
+		pEngfuncs->Con_Printf("Writing %lu missed frames (time = %.8f).\n", missedFrames, time);
 
 	for (size_t i = 0; i < missedFrames; ++i)
 	{

--- a/AfxHookGoldSrc/filming.cpp
+++ b/AfxHookGoldSrc/filming.cpp
@@ -1932,7 +1932,15 @@ void FilmingStream::Capture(double time, CMdt_Media_RAWGLPIC * usePic, float sps
 
 	size_t framesWritten = 0;
 
-	while (m_NextFrameIsAt < time)
+	/*
+	 * If the player is seeing the current engine frame for more time than
+	 * the previous engine frame during the current video frame, use the current engine frame.
+	 *
+	 * This condition can be written as:
+	 * if the current engine time is closer to the current video frame time
+	 * than half of the video framerate.
+	 */
+	while (time - m_NextFrameIsAt > (1.0 / (spsHint * 2.0)))
 	{
 		WriteFrame(m_PreviousFrame, m_NextFrameIsAt);
 		m_NextFrameIsAt += (1.0 / spsHint);
@@ -1942,7 +1950,7 @@ void FilmingStream::Capture(double time, CMdt_Media_RAWGLPIC * usePic, float sps
 
 	m_PreviousFrame = *usePic;
 
-	if (m_NextFrameIsAt == time)
+	if (m_NextFrameIsAt <= time)
 	{
 		WriteFrame(m_PreviousFrame, m_NextFrameIsAt);
 		m_NextFrameIsAt += (1.0 / spsHint);

--- a/AfxHookGoldSrc/filming.h
+++ b/AfxHookGoldSrc/filming.h
@@ -76,6 +76,9 @@ private:
 	int m_X;
 	int m_Y;
 
+	CMdt_Media_RAWGLPIC m_PreviousFrame;
+	double m_NextFrameIsAt;
+
 	/// <summary>Implements IFramePrinter.</summary>
 	virtual void Print(unsigned char const * data);
 

--- a/AfxHookGoldSrc/filming.h
+++ b/AfxHookGoldSrc/filming.h
@@ -36,6 +36,7 @@ void GLfloatArrayToXByteArray(GLfloat *pBuffer, unsigned int width, unsigned int
 
 enum FILMING_BUFFER { FB_COLOR, FB_DEPTH, FB_ALPHA };
 enum FILMING_DEPTHFN { FD_INV, FD_LINEAR, FD_LOG };
+enum CAPTURE_MODE { NORMAL, TAS_EXECUTION };
 
 
 class FilmingStream :
@@ -49,6 +50,7 @@ public:
 		wchar_t const * takePath, wchar_t const * name,
 		FILMING_BUFFER buffer,
 		double samplingFrameDuration,
+		CAPTURE_MODE captureMode,
 		int x, int y, int width, int height
 	);
 	~FilmingStream();
@@ -75,7 +77,7 @@ private:
 	int m_Width;
 	int m_X;
 	int m_Y;
-
+	CAPTURE_MODE m_CaptureMode;
 	CMdt_Media_RAWGLPIC m_PreviousFrame;
 	double m_NextFrameIsAt;
 
@@ -233,6 +235,7 @@ private:
 	float m_fps;
 	double m_time;
 	double m_LastHostTime;
+	CAPTURE_MODE m_CaptureMode;
 
 
 	CHlaeSupportRender *_pSupportRender;

--- a/AfxHookGoldSrc/filming.h
+++ b/AfxHookGoldSrc/filming.h
@@ -79,6 +79,8 @@ private:
 	CMdt_Media_RAWGLPIC m_PreviousFrame;
 	double m_NextFrameIsAt;
 
+	void WriteFrame(CMdt_Media_RAWGLPIC& frame, double time);
+
 	/// <summary>Implements IFramePrinter.</summary>
 	virtual void Print(unsigned char const * data);
 

--- a/AfxHookGoldSrc/filming.h
+++ b/AfxHookGoldSrc/filming.h
@@ -36,7 +36,6 @@ void GLfloatArrayToXByteArray(GLfloat *pBuffer, unsigned int width, unsigned int
 
 enum FILMING_BUFFER { FB_COLOR, FB_DEPTH, FB_ALPHA };
 enum FILMING_DEPTHFN { FD_INV, FD_LINEAR, FD_LOG };
-enum CAPTURE_MODE { NORMAL, TAS_EXECUTION };
 
 
 class FilmingStream :
@@ -50,7 +49,7 @@ public:
 		wchar_t const * takePath, wchar_t const * name,
 		FILMING_BUFFER buffer,
 		double samplingFrameDuration,
-		CAPTURE_MODE captureMode,
+		bool TASMode,
 		int x, int y, int width, int height
 	);
 	~FilmingStream();
@@ -77,7 +76,7 @@ private:
 	int m_Width;
 	int m_X;
 	int m_Y;
-	CAPTURE_MODE m_CaptureMode;
+	bool m_TASMode;
 	CMdt_Media_RAWGLPIC m_PreviousFrame;
 	double m_NextFrameIsAt;
 
@@ -235,7 +234,7 @@ private:
 	float m_fps;
 	double m_time;
 	double m_LastHostTime;
-	CAPTURE_MODE m_CaptureMode;
+	bool m_TASMode;
 
 
 	CHlaeSupportRender *_pSupportRender;

--- a/AfxHookGoldSrc/hooks/HookGameLoaded.cpp
+++ b/AfxHookGoldSrc/hooks/HookGameLoaded.cpp
@@ -30,8 +30,8 @@
 xcommand_t g_Old_connect = NULL;
 void Hook_connect(void)
 {
-	// Don't print the warning when in TAS execution mode.
-	if (pEngfuncs->pfnGetCvarFloat("mirv_capture_mode") == 1.0f)
+	// Don't print the warning when in TAS mode.
+	if (pEngfuncs->pfnGetCvarFloat("mirv_tas_mode") != 0.0f)
 		return g_Old_connect();
 
 	int imbret = MessageBoxA(NULL,

--- a/AfxHookGoldSrc/hooks/HookGameLoaded.cpp
+++ b/AfxHookGoldSrc/hooks/HookGameLoaded.cpp
@@ -30,6 +30,10 @@
 xcommand_t g_Old_connect = NULL;
 void Hook_connect(void)
 {
+	// Don't print the warning when in TAS execution mode.
+	if (pEngfuncs->pfnGetCvarFloat("mirv_capture_mode") == 1.0f)
+		return g_Old_connect();
+
 	int imbret = MessageBoxA(NULL,
 		"WARNING: You are about to connect to a server.\n"
 		"It is strongly recommended to NOT connect to any server while HLAE is running!\n"

--- a/AfxHookGoldSrc/mdt_media.cpp
+++ b/AfxHookGoldSrc/mdt_media.cpp
@@ -183,6 +183,60 @@ CMdt_Media_RAWGLPIC::~CMdt_Media_RAWGLPIC()
 	_freeAndClean();
 }
 
+void CMdt_Media_RAWGLPIC::swap(CMdt_Media_RAWGLPIC& o)
+{
+	#define SWAP(x) std::swap(x, o.x)
+
+	SWAP(_pBuffer);
+	SWAP(_uiSize);
+	SWAP(_uiBytesAllocated);
+
+	SWAP(_bHasConsistentData);
+	SWAP(_iWidth);
+	SWAP(_iHeight);
+
+	SWAP(_eGLformat);
+	SWAP(_eGLtype);
+
+	SWAP(_uiPixelSize);
+	SWAP(_ucSizeComponent);
+	SWAP(_ucNumComponents);
+	SWAP(_bComponentIsSigned);
+
+	#undef SWAP
+}
+
+CMdt_Media_RAWGLPIC::CMdt_Media_RAWGLPIC(const CMdt_Media_RAWGLPIC& o)
+	: CMdt_Media_RAWGLPIC()
+{
+	_adjustMemory(o._uiSize, false);
+	std::memcpy(_pBuffer, o._pBuffer, _uiSize);
+
+	_bHasConsistentData = o._bHasConsistentData;
+	_iWidth = o._iWidth;
+	_iHeight = o._iHeight;
+
+	_eGLformat = o._eGLformat;
+	_eGLtype = o._eGLtype;
+
+	_uiPixelSize = o._uiPixelSize;
+	_ucSizeComponent = o._ucSizeComponent;
+	_ucNumComponents = o._ucNumComponents;
+	_bComponentIsSigned = o._bComponentIsSigned;
+}
+
+CMdt_Media_RAWGLPIC::CMdt_Media_RAWGLPIC(CMdt_Media_RAWGLPIC&& o)
+	: CMdt_Media_RAWGLPIC()
+{
+	swap(o);
+}
+
+CMdt_Media_RAWGLPIC& CMdt_Media_RAWGLPIC::operator=(CMdt_Media_RAWGLPIC rhs)
+{
+	swap(rhs);
+	return *this;
+}
+
 // DoGlReadPixels:
 bool CMdt_Media_RAWGLPIC::DoGlReadPixels(int iXofs, int iYofs, int iWidth, int iHeight, GLenum eGLformat, GLenum eGLtype, bool bRepack)
 {

--- a/AfxHookGoldSrc/mdt_media.cpp
+++ b/AfxHookGoldSrc/mdt_media.cpp
@@ -10,6 +10,8 @@ Description : see mdt_media.h
 
 #include "mdt_media.h"
 
+#include <algorithm>
+
 //#define MDT_DEBUG
 #ifdef MDT_DEBUG
 	#include <stdio.h> // _snprintf

--- a/AfxHookGoldSrc/mdt_media.h
+++ b/AfxHookGoldSrc/mdt_media.h
@@ -81,9 +81,15 @@ class CMdt_Media_RAWGLPIC : public CMdt_Media_BASE
 //   Simply call DoGlReadPixels with your needs, the class will try to adjust everything as far as possible.
 //   The data and service functions can be trusted if DoGlReadPixels returns with true (it also set's HasConsistentData to true in this case).
 {
+private:
+	void swap(CMdt_Media_RAWGLPIC& o);
+
 public:
 	CMdt_Media_RAWGLPIC(); // Constructor, use this one if you want to only use autodetection
 	~CMdt_Media_RAWGLPIC();	// destructor
+	CMdt_Media_RAWGLPIC(const CMdt_Media_RAWGLPIC& o);
+	CMdt_Media_RAWGLPIC(CMdt_Media_RAWGLPIC&& o);
+	CMdt_Media_RAWGLPIC& operator=(CMdt_Media_RAWGLPIC rhs);
 
 	// glReadPixels - we always use glCoords here
 


### PR DESCRIPTION
This PR adds a new TAS execution capture mode, toggled with CVar `mirv_tas_mode`. When this capture mode is used, instead of forcing the engine FPS with `host_framerate` HLAE takes frames from the engine at the rate they arrive, and saves them (including frame duplication or deletion where necessary) as a constant FPS image sequence (at `mirv_movie_fps` FPS).

This mode is intended to be used for capturing Tool-Assisted Speedruns not from demos, but directly when they are being executed. Since this involves starting and changing maps, the VAC ban warning message box is disabled when the mode is enabled.